### PR TITLE
Improve OCR data processing scripts with robust regex

### DIFF
--- a/scripts/consolidate_data.py
+++ b/scripts/consolidate_data.py
@@ -1,28 +1,59 @@
+"""Combine the processed JSONL files into a single dataset.
+
+The script collects data produced by the other processing scripts and
+shuffles it into one final JSONL file.  Basic error handling is included
+so that missing or malformed input files do not cause the consolidation
+to abort.
+"""
+
 import json
 import random
 from pathlib import Path
 
-def consolidate_data(input_dir, output_file='final_dataset.jsonl'):
-    """
-    Combines and shuffles all processed data files into one final dataset.
-    """
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+PROCESSED_DIR = Path("data") / "processed"
+OUTPUT_FILE = PROCESSED_DIR / "final_dataset.jsonl"
+
+# These are the expected intermediate files.  Missing files are skipped
+# with a warning.
+EXPECTED_FILES = [
+    "instruction_data.jsonl",
+    "lookup_data.jsonl",
+    "monolingual_data.jsonl",
+]
+
+
+def consolidate_data(input_dir: Path, output_file: Path = OUTPUT_FILE):
+    """Combine and shuffle JSONL files from *input_dir* into *output_file*."""
+
     all_data = []
-    
-    # Use glob to find all .jsonl files in the processed directory
-    for file_path in input_dir.glob('*.jsonl'):
-        print(f"Reading from {file_path}...")
-        with open(file_path, 'r', encoding='utf-8') as f:
-            for line in f:
-                all_data.append(json.loads(line))
-    
+
+    for filename in EXPECTED_FILES:
+        file_path = input_dir / filename
+        if not file_path.exists():
+            print(f"Warning: {file_path} not found. Skipping.")
+            continue
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        all_data.append(json.loads(line))
+                    except json.JSONDecodeError:
+                        print(f"Warning: Skipping malformed line in {file_path}")
+        except OSError as err:
+            print(f"Warning: Could not read {file_path}: {err}")
+
     random.shuffle(all_data)
 
-    with open(output_file, 'w', encoding='utf-8') as f:
+    with open(output_file, "w", encoding="utf-8") as f:
         for item in all_data:
-            f.write(json.dumps(item, ensure_ascii=False) + '\n')
+            f.write(json.dumps(item, ensure_ascii=False) + "\n")
 
     print(f"Consolidated and shuffled {len(all_data)} items into {output_file}")
 
-# Example usage
-PROCESSED_DIR = Path('data') / 'processed'
-consolidate_data(PROCESSED_DIR, output_file=PROCESSED_DIR / 'final_dataset.jsonl')
+
+if __name__ == "__main__":
+    consolidate_data(PROCESSED_DIR, OUTPUT_FILE)
+

--- a/scripts/process_lookup_data.py
+++ b/scripts/process_lookup_data.py
@@ -1,14 +1,34 @@
-import re
+"""Extract dictionary style lookup data from an OCR'd document.
+
+The document contains both abbreviations and dictionary entries with a
+large amount of inconsistent spacing and punctuation produced by the OCR
+process.  The regular expressions here are therefore designed to be
+fairly permissive so that minor variations (e.g. ``adj. - Adjective`` or
+``omuntu  n.   person``) are still captured correctly.
+"""
+
 import json
-from docx import Document
+import re
 from pathlib import Path
 
-# ... (Configuration section as before)
+from docx import Document
 
-def extract_lookup_data(doc_path):
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+DOC_PATH = Path("data") / "raw" / "grammar" / "RUNYAKITARA LANGUAGE STUDIES.docx"
+
+OUTPUT_DIR = Path("data") / "processed"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+OUTPUT_FILE = OUTPUT_DIR / "lookup_data.jsonl"
+
+
+def extract_lookup_data(doc_path: Path):
+    """Extract abbreviations and dictionary entries from *doc_path*.
+
+    Returns a list of dictionaries that can be written to a JSONL file.
     """
-    Extracts lookup-style data from the specified DOCX file.
-    """
+
     if not doc_path.exists():
         print(f"Error: Document not found at {doc_path}")
         return []
@@ -16,37 +36,52 @@ def extract_lookup_data(doc_path):
     document = Document(doc_path)
     structured_data = []
 
-    print("--- Starting Debugging: Printing Raw Paragraph Text ---")
+    # Matches abbreviations such as ``adj. - Adjective`` where the dash is
+    # optional and arbitrary whitespace is tolerated.
+    abbr_pattern = re.compile(r"^([A-Za-z]+\.?)\s*[-–]?\s+(.*)$")
+
+    # Matches dictionary entries like ``omuntu n. person`` or ``genda v.-to go``.
+    # The part of speech can vary (n., v., adj., adv., etc.).
+    dict_pattern = re.compile(
+        r"^([A-Za-z'’]+)\s+(?:n\.|v\.|adj\.|adv\.|pron\.|prep\.|conj\.|interj\.)\s*[-–]?\s*(.+)$",
+        re.IGNORECASE,
+    )
+
     for para in document.paragraphs:
         text = para.text.strip()
         if not text:
             continue
-        print(f"Checking paragraph: '{text}'")
 
-        # Your pattern-matching code is here
-        abbr_match = re.match(r"^(\w+\.?)\s+(.*)", text)
+        abbr_match = abbr_pattern.match(text)
         if abbr_match:
-            print(f"  -> Found Abbreviation: '{abbr_match.group(1)}' -> '{abbr_match.group(2)}'")
-            structured_data.append({
-                "type": "lookup",
-                "runyoro_term": abbr_match.group(1),
-                "english_term": abbr_match.group(2),
-                "category": "Abbreviations"
-            })
+            structured_data.append(
+                {
+                    "type": "lookup",
+                    "runyoro_term": abbr_match.group(1).strip(),
+                    "english_term": abbr_match.group(2).strip(),
+                    "category": "Abbreviations",
+                }
+            )
             continue
 
-        dict_match = re.match(r"^(\w+)\s+n\.\s+(.*)", text)
+        dict_match = dict_pattern.match(text)
         if dict_match:
-            print(f"  -> Found Dictionary Entry: '{dict_match.group(1)}' -> '{dict_match.group(2)}'")
-            structured_data.append({
-                "type": "lookup",
-                "runyoro_term": dict_match.group(1),
-                "english_term": dict_match.group(2),
-                "category": "Dictionary"
-            })
-            continue
-    print("--- End of Debugging ---")
+            structured_data.append(
+                {
+                    "type": "lookup",
+                    "runyoro_term": dict_match.group(1).strip(),
+                    "english_term": dict_match.group(2).strip(),
+                    "category": "Dictionary",
+                }
+            )
 
     return structured_data
 
-# ... (Example usage as before)
+
+if __name__ == "__main__":
+    lookup_data = extract_lookup_data(DOC_PATH)
+    with open(OUTPUT_FILE, "w", encoding="utf-8") as f:
+        for item in lookup_data:
+            f.write(json.dumps(item, ensure_ascii=False) + "\n")
+    print(f"Lookup data saved to {OUTPUT_FILE}")
+


### PR DESCRIPTION
## Summary
- make noun class extraction tolerant of OCR artefacts and multi-line examples
- add flexible patterns for abbreviations and dictionary entries
- rebuild monolingual paragraph extraction and add error-handled consolidation

## Testing
- `python scripts/process_instruction_data.py`
- `python scripts/process_lookup_data.py`
- `python scripts/process_monolingual_data.py`
- `python scripts/consolidate_data.py`


------
https://chatgpt.com/codex/tasks/task_e_688f61ddd874832b8458f83ee0752f56